### PR TITLE
Refactor getting_started messages into toolchain

### DIFF
--- a/.bluemix/locales_getting_started.yml
+++ b/.bluemix/locales_getting_started.yml
@@ -1,0 +1,29 @@
+---
+root:
+  $ref: ./nls/messages_getting_started.yml
+de:
+  $ref: ./nls/messages_getting_started_de.yml
+en-AA:
+  $ref: ./nls/messages_getting_started_en_AA.yml
+en-RR:
+  $ref: ./nls/messages_getting_started_en_RR.yml
+en-ZZ:
+  $ref: ./nls/messages_getting_started_en_ZZ.yml
+es:
+  $ref: ./nls/messages_getting_started_es.yml
+fr:
+  $ref: ./nls/messages_getting_started_fr.yml
+it:
+  $ref: ./nls/messages_getting_started_it.yml
+ja:
+  $ref: ./nls/messages_getting_started_ja.yml
+ko:
+  $ref: ./nls/messages_getting_started_ko.yml
+pt-BR:
+  $ref: ./nls/messages_getting_started_pt_BR.yml
+zh:
+  $ref: ./nls/messages_getting_started_zh.yml
+zh-HK:
+  $ref: ./nls/messages_getting_started_zh_HK.yml
+zh-TW:
+  $ref: ./nls/messages_getting_started_zh_TW.yml

--- a/.bluemix/nls/messages.yml
+++ b/.bluemix/nls/messages.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Garage Method Cloud-native Tutorial"
 template.description: "This toolchain demonstrates the DevOps practices featured in the Bluemix Garage Method. The toolchain is preconfigured for continuous delivery, source control, test automation, and automated monitoring and operations. It comes with a sample app that is written in Node.js [Express 4](http://expressjs.com/), which you can further extend. This sample code is used in a [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) that explains how to configure a toolchain for cloud-native development.\n\nTo set up and run stages of the pipeline, you might need to register for other tools or services. The tutorial guides you through those details.\n\nTo get started, click **Create**."
-template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)  for this toolchain."
 deploy.title: "Sample Deploy Stage"
 deploy.description: "sample toolchain"
 deploy.longDescription: "The Delivery Pipeline automates continuous deployment."

--- a/.bluemix/nls/messages_de.yml
+++ b/.bluemix/nls/messages_de.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Cloudnatives Lernprogramm für Garage Method"
 template.description: "Diese Toolchain demonstriert die DevOps-Verfahren, die in Bluemix Garage Method eingesetzt werden. Die Toolchain ist für die kontinuierliche Bereitstellung, Quellcodeverwaltung, Testautomatisierung sowie automatisierte Überwachung und Operationen vorkonfiguriert. Sie wird mit einer Beispielapp geliefert, die in Node.js [Express 4](http://expressjs.com/) geschrieben ist und von Ihnen erweitert werden kann. Dieser Beispielcode wird in einem [Lernprogramm](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) verwendet, das erklärt, wie Sie eine Toolchain für die cloudnative Entwicklung konfigurieren.\n\nUm die Phasen der Pipeline einrichten und ausführen zu können, müssen Sie sich möglicherweise für andere Tools oder Services registrieren. Das Lernprogramm führt Sie durch diese Details.\n\nKlicken Sie auf **Erstellen**, um zu beginnen."
-template.gettingStarted: "**Ihre Toolchain steht bereit!**\n**Schnelleinstieg:** Schreiben Sie eine Änderung im Git-Repository fest, um einen neuen Build und eine neue Bereitstellung auszulösen. Schrittweise Anleitungen finden Sie im [Lernprogramm](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) für diese Toolchain."
 deploy.title: "Beispielbereitstellungsphase"
 deploy.description: "Beispieltoolchain"
 deploy.longDescription: "Mit Delivery Pipeline wird die kontinuierliche Bereitstellung automatisiert."

--- a/.bluemix/nls/messages_en_AA.yml
+++ b/.bluemix/nls/messages_en_AA.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "1:Garage Method Cloud-native Tutorial"
 template.description: "2:This toolchain demonstrates the DevOps practices featured in the Bluemix Garage Method. The toolchain is preconfigured for continuous delivery, source control, test automation, and automated monitoring and operations. It comes with a sample app that is written in Node.js [Express 4](http://expressjs.com/), which you can further extend. This sample code is used in a [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) that explains how to configure a toolchain for cloud-native development.\n\nTo set up and run stages of the pipeline, you might need to register for other tools or services. The tutorial guides you through those details.\n\nTo get started, click **Create**."
-template.gettingStarted: "3:**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)  for this toolchain."
 deploy.title: "4:Sample Deploy Stage"
 deploy.description: "5:sample toolchain"
 deploy.longDescription: "6:The Delivery Pipeline automates continuous deployment."

--- a/.bluemix/nls/messages_en_RR.yml
+++ b/.bluemix/nls/messages_en_RR.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Garage Method Cloud-native Tutorial~otc-ui516"
 template.description: "This toolchain demonstrates the DevOps practices featured in the Bluemix Garage Method. The toolchain is preconfigured for continuous delivery, source control, test automation, and automated monitoring and operations. It comes with a sample app that is written in Node.js [Express 4](http://expressjs.com/), which you can further extend. This sample code is used in a [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) that explains how to configure a toolchain for cloud-native development.\n\nTo set up and run stages of the pipeline, you might need to register for other tools or services. The tutorial guides you through those details.\n\nTo get started, click **Create**.~otc-ui517"
-template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)  for this toolchain.~otc-ui518"
 deploy.title: "Sample Deploy Stage~otc-ui519"
 deploy.description: "sample toolchain~otc-ui520"
 deploy.longDescription: "The Delivery Pipeline automates continuous deployment.~otc-ui521"

--- a/.bluemix/nls/messages_en_ZZ.yml
+++ b/.bluemix/nls/messages_en_ZZ.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "[G'Ｇａｒａｇｅ Ｍｅｔｈod Cloud-native Tutorialฏูİı｜]"
 template.description: "[G'Ｔｈｉｓ ｔｏｏｌｃｈａｉｎ ｄｅｍｏｎｓｔｒａｔｅｓ ｔｈｅ ＤｅｖＯｐｓ ｐｒａｃｔｉｃｅｓ ｆｅａｔｕｒｅｄ ｉｎ ｔｈｅ Ｂｌｕｅｍｉｘ Ｇａｒａｇｅ Ｍｅｔｈｏｄ. Ｔｈｅ ｔｏｏｌｃｈａｉｎ ｉｓ ｐｒｅｃｏｎｆｉｇｕｒｅｄ ｆｏｒ ｃｏｎｔｉｎｕｏｕｓ ｄｅｌｉｖｅｒｙ, ｓｏｕｒｃｅ ｃｏｎｔｒｏｌ, ｔｅｓｔ ａｕｔｏｍａｔｉｏｎ, ａｎｄ ａｕｔｏｍａｔｅｄ ｍｏｎｉｔｏｒｉｎｇ ａｎｄ ｏｐｅｒａｔｉｏｎｓ. Ｉｔ ｃｏｍｅｓ ｗｉｔｈ ａ ｓａｍｐle app that is written in Node.js [Express 4](http://expressjs.com/), which you can further extend. This sample code is used in a [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) that explains how to configure a toolchain for cloud-native development.\n\nTo set up and run stages of the pipeline, you might need to register for other tools or services. The tutorial guides you through those details.\n\nTo get started, click **Create**.ฏูİı｜]"
-template.gettingStarted: "[G'**Ｙｏｕｒ ｔｏｏｌｃｈａｉｎ ｉｓ ｒｅａｄｙ!**\n**Ｑｕｉｃｋ ｓｔａｒｔ:** Ｃｏｍｍｉｔ ａ ｃｈａｎｇｅ ｔｏ ｔｈｅ Ｇｉｔ ｒｅｐｏ ｔｏ ｔｒｉｇｇｅｒ ａ ｎｅw build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)  for this toolchain.ฏูİı｜]"
 deploy.title: "[G'Ｓａｍｐｌｅ Deploy Stageฏูİı｜]"
 deploy.description: "[G'ｓａｍｐｌe toolchainฏูİı｜]"
 deploy.longDescription: "[G'Ｔｈｅ Ｄｅｌｉｖｅｒｙ Ｐipeline automates continuous deployment.ฏูİı｜]"

--- a/.bluemix/nls/messages_es.yml
+++ b/.bluemix/nls/messages_es.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Guía de aprendizaje para cadena de herramientas nativas y de nube para Garage Method"
 template.description: "Esta cadena de herramientas demuestra las prácticas de DevOps destacadas en Bluemix Garage Method. La cadena de herramientas está configurada de forma previa para entrega continua, control de origen, automatización de pruebas y supervisión y pruebas automatizadas. Viene con una aplicación de ejemplo escrita en Node.js [Express 4](http://expressjs.com/), que puede ampliar con posterioridad. Este código de ejemplo se utiliza en la [guía de aprendizaje](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) que explica cómo configurar una cadena de herramientas para el desarrollo nativo y de nube. \n\nPara configurar y ejecutar etapas del conducto, es posible que necesite registrarse para otras herramientas o servicios. La guía de aprendizaje le guía a través de esos detalles.\n\nPara comenzar, pulse **Crear**."
-template.gettingStarted: "**¡Su cadena de herramientas está lista!**\n**Inicio rápido:** Confirmar un cambio en el repositorio Git para desencadenar una nueva compilación y despliegue. Para obtener instrucciones detalladas paso a paso, consulte la [guía de aprendizaje](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)  para esta cadena de herramientas. "
 deploy.title: "Sample Deploy Stage"
 deploy.description: "cadena de herramientas de ejemplo"
 deploy.longDescription: "Delivery Pipeline automatiza el despliegue continuo."

--- a/.bluemix/nls/messages_fr.yml
+++ b/.bluemix/nls/messages_fr.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Garage Method - Tutoriel natif pour le cloud"
 template.description: "Cette chaîne d'outils illustre les pratiques DevOps appliquées dans Bluemix Garage Method. Elle est préconfigurée pour la distribution continue, le contrôle des sources et l'automatisation des tests, ainsi que pour la surveillance et les opérations automatisées. Elle est fournie avec un modèle d'application écrit en Node.js [Express 4](http://expressjs.com/), que vous pouvez continuer à étendre. Cet exemple de code est utilisé dans un [tutoriel](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) qui explique comment configurer une chaîne d'outils en vue du développement natif pour le cloud.\n\nPour configurer et exécuter les phases du pipeline, vous devrez peut-être vous enregistrer auprès d'autres outils ou services. Le tutoriel vous guide tout au long de ce processus. \n\nPour commencer, cliquez sur **Créer**."
-template.gettingStarted: "**Votre chaîne d'outils est prête !**\n**Démarrage rapide :** validez une modification dans le référentiel Git afin de déclencher une nouvelle génération et un nouveau déploiement. Pour obtenir des instructions étape par étape, reportez-vous au [tutoriel](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) relatif à cette chaîne d'outils. "
 deploy.title: "Etape de déploiement exemple"
 deploy.description: "Chaîne d'outils exemple"
 deploy.longDescription: "Delivery Pipeline automatise le déploiement en continu."

--- a/.bluemix/nls/messages_getting_started.yml
+++ b/.bluemix/nls/messages_getting_started.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)  for this toolchain."

--- a/.bluemix/nls/messages_getting_started_de.yml
+++ b/.bluemix/nls/messages_getting_started_de.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Ihre Toolchain steht bereit!**\n**Schnelleinstieg:** Schreiben Sie eine Änderung im Git-Repository fest, um einen neuen Build und eine neue Bereitstellung auszulösen. Schrittweise Anleitungen finden Sie im [Lernprogramm](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) für diese Toolchain."

--- a/.bluemix/nls/messages_getting_started_en_AA.yml
+++ b/.bluemix/nls/messages_getting_started_en_AA.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "3:**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)  for this toolchain."

--- a/.bluemix/nls/messages_getting_started_en_RR.yml
+++ b/.bluemix/nls/messages_getting_started_en_RR.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Your toolchain is ready!**\n**Quick start:** Commit a change to the Git repo to trigger a new build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)  for this toolchain.~otc-ui518"

--- a/.bluemix/nls/messages_getting_started_en_ZZ.yml
+++ b/.bluemix/nls/messages_getting_started_en_ZZ.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "[G'**Ｙｏｕｒ ｔｏｏｌｃｈａｉｎ ｉｓ ｒｅａｄｙ!**\n**Ｑｕｉｃｋ ｓｔａｒｔ:** Ｃｏｍｍｉｔ ａ ｃｈａｎｇｅ ｔｏ ｔｈｅ Ｇｉｔ ｒｅｐｏ ｔｏ ｔｒｉｇｇｅｒ ａ ｎｅw build and deployment. For step-by-step instructions, see the [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)  for this toolchain.ฏูİı｜]"

--- a/.bluemix/nls/messages_getting_started_es.yml
+++ b/.bluemix/nls/messages_getting_started_es.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**¡Su cadena de herramientas está lista!**\n**Inicio rápido:** Confirmar un cambio en el repositorio Git para desencadenar una nueva compilación y despliegue. Para obtener instrucciones detalladas paso a paso, consulte la [guía de aprendizaje](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)  para esta cadena de herramientas. "

--- a/.bluemix/nls/messages_getting_started_fr.yml
+++ b/.bluemix/nls/messages_getting_started_fr.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Votre chaîne d'outils est prête !**\n**Démarrage rapide :** validez une modification dans le référentiel Git afin de déclencher une nouvelle génération et un nouveau déploiement. Pour obtenir des instructions étape par étape, reportez-vous au [tutoriel](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) relatif à cette chaîne d'outils. "

--- a/.bluemix/nls/messages_getting_started_it.yml
+++ b/.bluemix/nls/messages_getting_started_it.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**La toolchain è pronta!**\n**Avvio rapido:** Eseguire il commit di una modifica al repository Git per attivare una nuova build e distribuzione.Per le istruzioni passo dopo passo, consultare il [supporto didattico](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) per questa toolchain."

--- a/.bluemix/nls/messages_getting_started_ja.yml
+++ b/.bluemix/nls/messages_getting_started_ja.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**ツールチェーンの準備ができました。**\n**クイック・スタート:** Git リポジトリーに対する変更をコミットし、新しいビルドおよびデプロイメントをトリガーしてください。ステップバイステップの説明については、このツールチェーンの[チュートリアル](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)を参照してください。"

--- a/.bluemix/nls/messages_getting_started_ko.yml
+++ b/.bluemix/nls/messages_getting_started_ko.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**도구 체인이 준비되었습니다!**\n**빠른 시작:** Git 저장소에 변경사항을 커미트하여 새 빌드와 배치를 트리거하십시오. 단계별 지시사항은 이 도구 체인의 [튜토리얼](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)을 참조하십시오."

--- a/.bluemix/nls/messages_getting_started_pt_BR.yml
+++ b/.bluemix/nls/messages_getting_started_pt_BR.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**Sua cadeia de ferramentas está pronta!**\n**Iniciação rápida:** Confirme uma mudança no repositório Git para acionar uma nova compilação e implementação. Para obter instruções passo a passo, consulte o [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) para esta cadeia de ferramentas."

--- a/.bluemix/nls/messages_getting_started_zh.yml
+++ b/.bluemix/nls/messages_getting_started_zh.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**工具链已就绪！**\n**快速启动：** 将更改落实到 Git 存储库以触发新的构建和部署。有关逐步指示信息，请参阅此工具链的[教程](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)。"

--- a/.bluemix/nls/messages_getting_started_zh_HK.yml
+++ b/.bluemix/nls/messages_getting_started_zh_HK.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 確定 Git 儲存庫的變更，以觸發新的建置及部署。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)。"

--- a/.bluemix/nls/messages_getting_started_zh_TW.yml
+++ b/.bluemix/nls/messages_getting_started_zh_TW.yml
@@ -1,0 +1,2 @@
+---
+template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 確定 Git 儲存庫的變更，以觸發新的建置及部署。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)。"

--- a/.bluemix/nls/messages_it.yml
+++ b/.bluemix/nls/messages_it.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Supporto didattico Cloud Garage Method nativo"
 template.description: "Questa toolchain dimostra le pratiche DevOps menzionate in Bluemix Garage Method. La toolchain è preconfigurata per la fornitura continua, il controllo origine, l'automazione del test e per le operazioni ed il monitoraggio automatizzato. Ciò avviene utilizzando un'app di esempio scritta in Node.js [Express 4](http://expressjs.com/), che è possibile estendere ulteriormente.Questo codice di esempio viene utilizzato in un [supporto didattico](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) che illustra in che modo configurare una toolchain per lo sviluppo per cloud nativo.\n\nPer configurare ed eseguire gli stage della pipeline, è necessario registrarsi agli altri strumenti o servizi.Il supporto didattico guida l'utente attraverso questi dettagli.\n\nPer iniziare, fare clic su **Crea**."
-template.gettingStarted: "**La toolchain è pronta!**\n**Avvio rapido:** Eseguire il commit di una modifica al repository Git per attivare una nuova build e distribuzione.Per le istruzioni passo dopo passo, consultare il [supporto didattico](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) per questa toolchain."
 deploy.title: "Stage di distribuzione di esempio"
 deploy.description: "toolchain di esempio"
 deploy.longDescription: "Delivery Pipeline automatizza la distribuzione continua."

--- a/.bluemix/nls/messages_ja.yml
+++ b/.bluemix/nls/messages_ja.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Garage Method クラウド・ネイティブ・チュートリアル"
 template.description: "このツールチェーンでは、Bluemix Garage Method で特徴づけられる DevOps の活動が示されます。このツールチェーンは、継続的デリバリー、ソース管理、テスト自動化、自動化されたモニター、および自動化された操作用に事前構成されています。これには、Node.js [Express 4](http://expressjs.com/) で作成されたサンプル・アプリが付属します。このアプリは、さらに拡張できます。このサンプル・コードは、クラウド・ネイティブ開発用にツールチェーンを構成する方法が説明されている[チュートリアル](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)で使用されます。\n\nパイプラインのステージをセットアップして実行するには、他のツールやサービスの登録が必要となることがあります。このチュートリアルに詳しい手引きが記載されています。\n\n開始するには、**「作成」**をクリックします。"
-template.gettingStarted: "**ツールチェーンの準備ができました。**\n**クイック・スタート:** Git リポジトリーに対する変更をコミットし、新しいビルドおよびデプロイメントをトリガーしてください。ステップバイステップの説明については、このツールチェーンの[チュートリアル](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)を参照してください。"
 deploy.title: "サンプルのデプロイ・ステージ"
 deploy.description: "サンプル・ツールチェーン"
 deploy.longDescription: "Delivery Pipeline は、継続的デプロイメントを自動化します。"

--- a/.bluemix/nls/messages_ko.yml
+++ b/.bluemix/nls/messages_ko.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Garage Method 클라우드 네이티브 튜토리얼"
 template.description: "이 도구 체인은 Bluemix Garage Method에 제공되는 DevOps 사례를 보여줍니다. 이 도구 체인은 지속적 딜리버리, 소스 제어, 테스트 자동화, 자동화된 모니터링 및 오퍼레이션을 위해 사전 구성되어 있습니다. 추가로 확장할 수 있는 Node.js [Express 4](http://expressjs.com/)로 작성한 샘플 앱이 함께 제공됩니다. 이 샘플 코드는 클라우드 네이티브 개발에 맞게 도구 체인을 구성하는 방법을 설명하는 [튜토리얼](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)에서 사용됩니다. \n\n파이프라인의 단계를 설정하고 실행하려면 다른 도구나 서비스를 등록해야 할 수도 있습니다. 이 튜토리얼에서 세부사항을 안내합니다. \n\n계속하려면 **작성**을 클릭하십시오."
-template.gettingStarted: "**도구 체인이 준비되었습니다!**\n**빠른 시작:** Git 저장소에 변경사항을 커미트하여 새 빌드와 배치를 트리거하십시오. 단계별 지시사항은 이 도구 체인의 [튜토리얼](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)을 참조하십시오."
 deploy.title: "샘플 배치 단계"
 deploy.description: "샘플 도구 체인"
 deploy.longDescription: "Delivery Pipeline은 지속적 배치를 자동화합니다."

--- a/.bluemix/nls/messages_pt_BR.yml
+++ b/.bluemix/nls/messages_pt_BR.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Tutorial nativo da nuvem do Método Garage"
 template.description: "Esta cadeia de ferramentas demonstra as práticas de DevOps em destaque no Método Garage do Bluemix. A cadeia de ferramentas é pré-configurada para entrega contínua, controle de fonte, automação de teste, bem como monitoramento e operações automatizados. Ele vem com um app de amostra gravado em Node.js [Express 4](http://expressjs.com/), que você pode ampliar ainda mais. Esse código de amostra é usado em um [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) que explica como configurar uma cadeia de ferramentas para desenvolvimento nativo da nuvem.\n\nPara configurar e executar estágios do pipeline, você poderá precisar registrar-se em outras ferramentas e serviços. O tutorial guia você nesses detalhes.\n\nPara iniciar, clique em **Criar**."
-template.gettingStarted: "**Sua cadeia de ferramentas está pronta!**\n**Iniciação rápida:** Confirme uma mudança no repositório Git para acionar uma nova compilação e implementação. Para obter instruções passo a passo, consulte o [tutorial](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow) para esta cadeia de ferramentas."
 deploy.title: "Estágio de Implementação de Amostra"
 deploy.description: "cadeia de ferramentas de amostra"
 deploy.longDescription: "O Delivery Pipeline automatiza a implementação contínua."

--- a/.bluemix/nls/messages_zh.yml
+++ b/.bluemix/nls/messages_zh.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Garage Method 云本机教程"
 template.description: "此工具链演示了 Bluemix Garage Method 中特有的 DevOps 实践。预先配置了此工具链，以进行持续交付、源代码控制、测试自动化和自动监视与操作。它随附用 Node.js [Express 4](http://expressjs.com/) 编写的样本应用程序，可以对其做进一步扩展。此样本代码在[教程](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)中用于说明如何配置工具链以用于云本机开发。\n\n要设置并运行管道的各阶段，可能需要注册其他工具或服务。此教程将指导您逐步了解这些详细信息。\n\n单击**创建**以开始。"
-template.gettingStarted: "**工具链已就绪！**\n**快速启动：** 将更改落实到 Git 存储库以触发新的构建和部署。有关逐步指示信息，请参阅此工具链的[教程](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)。"
 deploy.title: "样本部署暂存区"
 deploy.description: "样本工具链"
 deploy.longDescription: "Delivery Pipeline 自动执行持续部署。"

--- a/.bluemix/nls/messages_zh_HK.yml
+++ b/.bluemix/nls/messages_zh_HK.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Garage Method 雲端原生指導教學"
 template.description: "此工具鏈示範 Bluemix Garage Method 中特有的 DevOps 作法。此工具鏈已針對持續交付、來源控制、測試自動化，以及自動監視及作業進行預先配置。其隨附以 Node.js 撰寫的範例應用程式 [Express 4](http://expressjs.com/)，您可以進一步擴充。此範例程式碼用於 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)，說明如何配置工具鏈進行雲端原生開發。\n\n若要設定及執行管線的暫置，您可能需要登錄其他工具或服務。此指導教學會引導您逐步瞭解這些細節。\n\n若要開始，請按一下**建立**。"
-template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 確定 Git 儲存庫的變更，以觸發新的建置及部署。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)。"
 deploy.title: "範例服務部署暫置"
 deploy.description: "範例工具鏈"
 deploy.longDescription: "Delivery Pipeline 會自動執行連續部署。"

--- a/.bluemix/nls/messages_zh_TW.yml
+++ b/.bluemix/nls/messages_zh_TW.yml
@@ -1,7 +1,6 @@
 ---
 template.name: "Garage Method 雲端原生指導教學"
 template.description: "此工具鏈示範 Bluemix Garage Method 中特有的 DevOps 作法。此工具鏈已針對持續交付、來源控制、測試自動化，以及自動監視及作業進行預先配置。其隨附以 Node.js 撰寫的範例應用程式 [Express 4](http://expressjs.com/)，您可以進一步擴充。此範例程式碼用於 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)，說明如何配置工具鏈進行雲端原生開發。\n\n若要設定及執行管線的暫置，您可能需要登錄其他工具或服務。此指導教學會引導您逐步瞭解這些細節。\n\n若要開始，請按一下**建立**。"
-template.gettingStarted: "**您的工具鏈已備妥！**\n**快速入門：** 確定 Git 儲存庫的變更，以觸發新的建置及部署。如需逐步指示，請參閱此工具鏈的 [指導教學](https://www.ibm.com/devops/method/tutorials/tutorial_toolchain_flow)。"
 deploy.title: "範例服務部署暫置"
 deploy.description: "範例工具鏈"
 deploy.longDescription: "Delivery Pipeline 會自動執行連續部署。"

--- a/.bluemix/toolchain.yml
+++ b/.bluemix/toolchain.yml
@@ -22,7 +22,7 @@ toolchain:
   name: 'cloud-native-toolchain-tutorial-{{timestamp}}'
   template:
     getting_started:
-      $ref: "#/messages/template.gettingStarted"
+      $ref: locales_getting_started.yml
 services:
   sample-repo:
     service_id: githubpublic


### PR DESCRIPTION
Store all translations of 'getting started' message in the `toolchain.template` field.
This allows the UI to choose which string to display according to the browser locale.